### PR TITLE
Added Support for Multiple random  Twilio Numbers as senders

### DIFF
--- a/config/laratwilio.php
+++ b/config/laratwilio.php
@@ -3,5 +3,5 @@
 return [
     'account_sid' => env('TWILIO_ACCOUNT_SID'),
     'auth_token' => env('TWILIO_AUTH_TOKEN'),
-    'sms_from' => env('TWILIO_SMS_FROM'),
+    'sms_from' => explode(',', env('TWILIO_SMS_FROM', '')), // Support multiple numbers as a comma-separated string
 ];

--- a/src/LaraTwilio.php
+++ b/src/LaraTwilio.php
@@ -14,11 +14,37 @@ class LaraTwilio
         $this->client = $client;
     }
 
-    public function notify(string $number, string $message)
+      /**
+     * Send an SMS notification.
+     *
+     * @param string $number Recipient phone number.
+     * @param string $message Message content.
+     * @param string|null $from Optional sender phone number.
+     * @return mixed Twilio API response.
+     */
+    public function notify(string $number, string $message, string $from = null)
     {
+        $from = $from ?: $this->getRandomFromNumber();
+
         return $this->client->messages->create($number, [
-            'from' => config('laratwilio.sms_from'),
+            'from' => $from,
             'body' => $message,
         ]);
+    }
+
+    /**
+     * Get a random Twilio number if multiple are available.
+     *
+     * @return string
+     */
+    protected function getRandomFromNumber()
+    {
+        $fromNumbers = config('laratwilio.sms_from', []);
+
+        if (!is_array($fromNumbers)) {
+            $fromNumbers = explode(',', $fromNumbers); // Convert comma-separated string to array if needed
+        }
+
+        return !empty($fromNumbers) ? $fromNumbers[array_rand($fromNumbers)] : null;
     }
 }

--- a/src/LaraTwilioServiceProvider.php
+++ b/src/LaraTwilioServiceProvider.php
@@ -6,8 +6,18 @@ use Exception;
 use Illuminate\Support\ServiceProvider;
 use Twilio\Rest\Client;
 
+/**
+ * Class LaraTwilioServiceProvider
+ *
+ * Service provider for LaraTwilio package.
+ */
 class LaraTwilioServiceProvider extends ServiceProvider
 {
+    /**
+     * Register services and bindings.
+     *
+     * @return void
+     */
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/laratwilio.php', 'laratwilio');
@@ -20,6 +30,11 @@ class LaraTwilioServiceProvider extends ServiceProvider
         });
     }
 
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
     public function boot()
     {
         if ($this->app->runningInConsole()) {
@@ -27,17 +42,31 @@ class LaraTwilioServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * Ensure validation.
+     *
+     * @return void
+     */
     protected function ensureConfigValuesAreSet()
     {
         $mandatoryAttributes = config('laratwilio');
 
-        foreach ($mandatoryAttributes as $key => $value) {
-            if (empty($value)) {
+        foreach (['account_sid', 'auth_token'] as $key) {
+            if (empty($mandatoryAttributes[$key])) {
                 throw new Exception("Please provide a value for ${key}");
             }
         }
+
+        if (empty($mandatoryAttributes['sms_from']) || !is_array($mandatoryAttributes['sms_from'])) {
+            throw new Exception("Please provide at least one valid Twilio SMS_FROM number.");
+        }
     }
 
+    /**
+     * Publish configuration file.
+     *
+     * @return void
+     */
     protected function publishConfig()
     {
         $this->publishes([


### PR DESCRIPTION
# PR Summary: Added Support for Multiple Random Twilio Numbers as Senders  

## Overview  
This PR enhances the `LaraTwilio` package by adding support for multiple Twilio numbers as senders. When sending SMS messages, the system can now randomly select a sender number from a predefined list in the configuration.  

## Key Updates  
✅ **Config Support for Multiple Numbers:**  
- The `sms_from` config now supports multiple sender numbers via a comma-separated `.env` value.  
- Automatically converts the string into an array for easy selection.  

✅ **Random Sender Selection:**  
- The `notify` method now dynamically picks a sender number if none is specified.  
- Uses `array_rand()` to select a number from the list in `config('laratwilio.sms_from')`.  


usage
`TWILIO_SMS_FROM=+1234567890,+0987654321`